### PR TITLE
Disable lunr stopWordFilter

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -21,6 +21,8 @@ superagent.get('corpus.csv').end()
       @field 'word'
       @ref 'word'
 
+  indexes.lunr.pipeline.remove(lunr.stopWordFilter)
+
   for word in words
     indexes.lunr.add {word: word}
   indexes


### PR DESCRIPTION
By default lunr includes a [stop word filter](http://lunrjs.com/docs/#stopWordFilter) ([code](https://github.com/olivernn/lunr.js/blob/master/lib/stop_word_filter.js)) to reduce the size of the index. I don't think the other search engines being tested do, so this change removes the stop word filter for a better comparison of search results.

Currently the stop word filter means queries like "the" will not return any results, if using this for autocomplete removing stop words is _possibly_ undesirable.
